### PR TITLE
update PlaceholderAPI and GlowingEntities in order to support 1.21.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ dependencies {
     compileOnly "io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT"
 
     //glowing entities
-    implementation 'fr.skytasul:glowingentities:1.3.5'
+    implementation 'fr.skytasul:glowingentities:1.4.3'
 
     //placeholderapi
-    compileOnly 'me.clip:placeholderapi:2.11.3'
+    compileOnly 'me.clip:placeholderapi:2.11.6'
 
     //lombok
     compileOnly 'org.projectlombok:lombok:1.18.34'


### PR DESCRIPTION
Note: PlaceholderAPI 2.11.3 is no longer available on [HelpChat Maven Repository](https://repo.extendedclip.com/#/) 